### PR TITLE
use fs.constants to support for new node.js versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,10 +38,13 @@ function openTTY() {
 }
 
 function rawConsole_win32() {
-    var fd
+    var fd;
+    var flag = (fs.constants !== undefined) ?
+            fs.constants.O_RDWR :
+            _constants.O_RDWR;
 
     try {
-        fd = _fs.open('CONIN$', _constants.O_RDWR, 438);
+        fd = _fs.open('CONIN$', flag, 438);
         var tty = new _TTY(fd, true);
         tty.setRawMode(true);
     } catch (e) {


### PR DESCRIPTION
The package relays on the private constant O_RDWR. In newer versions
of node.js there is `constants` object in the `fs` module,
from where the constant should be read.